### PR TITLE
Add Trac-to-Github-migration

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,13 @@
+   Copyright 2022 ACCESS-NRI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Trac-to-Github-migration/bin/bootstrap_tractive_users.py
+++ b/Trac-to-Github-migration/bin/bootstrap_tractive_users.py
@@ -1,0 +1,76 @@
+#!/bin/env python
+
+import argparse
+import github
+import re
+import sys
+import time
+import yaml
+
+from github import Auth
+from github_organization_token import token_str
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+        'map', 
+        nargs='?',
+        default='cable.map')
+parser.add_argument(
+        'bootstrap', 
+        nargs='?',
+        default='tractive.config.bootstrap.yaml')
+args = parser.parse_args()
+
+# GitHub authorization used for name lookup
+auth = Auth.Token(token_str)
+g = github.MainClass.Github(auth=auth)
+
+# Regular expression pattern matching args.map
+m_str = r'(?P<m_user>.*) = (?P<m_name>.*) <(?P<m_email>.*)>'
+m_pattern = re.compile(m_str)
+
+with open(args.map,'r') as m:
+    m_lines = m.readlines()
+
+# Use the dictionary t_users to collect users for Tractive
+t_users = dict()
+with open(args.bootstrap,'r') as b:
+    b_yaml = yaml.load(b.read(), Loader=yaml.Loader)
+    b_users =  b_yaml['users']
+    for b_user in b_users:
+        time.sleep(4)
+        print(b_user, file=sys.stderr, flush=True)
+        # If b_user includes multiple NCI usernames, use the first one
+        n_user = (b_user.split(',')[0]
+                if ',' in b_user else
+                b_user)
+        # Look for the NCI username n_user 
+        b_user_dict = b_users[n_user]
+        b_found = False
+        for m_line in m_lines:
+            m_match = m_pattern.match(m_line)
+            m_user = m_match.group('m_user')
+            if m_user == n_user:
+                b_found = True
+                m_name = m_match.group('m_name')
+                # Look up m_name as a GitHub user
+                g_result = g.search_users(m_name)
+                g_user = (
+                    g_result[0].login 
+                    if g_result.totalCount > 0 else
+                    'ccarouge')
+                m_email = m_match.group('m_email')
+                break
+        if b_found:
+            t_users[b_user] = {
+                    'email': m_email,
+                    'name': m_name,
+                    'username': g_user}
+        else:
+            t_users[b_user] = {
+                    'email': 'ccarouge@nci.org.au',
+                    'name': b_user,
+                    'username': 'ccarouge'}
+    t_yaml = {'users': t_users}
+    print(yaml.dump(t_yaml, Dumper=yaml.Dumper))
+

--- a/Trac-to-Github-migration/bin/bootstrap_tractive_users.py
+++ b/Trac-to-Github-migration/bin/bootstrap_tractive_users.py
@@ -1,4 +1,6 @@
 #!/bin/env python
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import github

--- a/Trac-to-Github-migration/bin/cable-git-filter-repo.pbs
+++ b/Trac-to-Github-migration/bin/cable-git-filter-repo.pbs
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 #PBS -l ncpus=1
 #PBS -l mem=4GB
 #PBS -l jobfs=4GB

--- a/Trac-to-Github-migration/bin/cable-git-filter-repo.pbs
+++ b/Trac-to-Github-migration/bin/cable-git-filter-repo.pbs
@@ -1,0 +1,21 @@
+#PBS -l ncpus=1
+#PBS -l mem=4GB
+#PBS -l jobfs=4GB
+#PBS -q normalbw
+#PBS -P tm70
+#PBS -l walltime=6:00:00
+#PBS -l storage=gdata/tm70
+#PBS -j oe
+
+source $HOME/.bashrc
+base="/g/data/tm70/pcl851/tractive/cable-trac-github"
+paths=$(cat "${base}/cable-git-large-files.largest.sorted.txt")
+log="${base}/logs/cable-git-filter-repo.log"
+
+conda_env_tractive
+cd "${base}/cable-git"
+for path in $paths; do 
+    echo "" >> $log
+    echo $path >> $log
+    git filter-repo --force --invert-paths --path $path 2>&1 >> $log
+done

--- a/Trac-to-Github-migration/bin/create_tractive_users_as_devs.py
+++ b/Trac-to-Github-migration/bin/create_tractive_users_as_devs.py
@@ -1,0 +1,59 @@
+#!/bin/env python
+
+import argparse
+import github
+import re
+import sys
+import time
+import yaml
+
+from github import Auth
+from github_organization_token import token_str
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+        'map', 
+        nargs='?',
+        default='cable.map')
+args = parser.parse_args()
+
+m_str = r'(?P<m_user>.*) = (?P<m_name>.*) <(?P<m_email>.*)>'
+m_pattern = re.compile(m_str)
+
+# GitHub authorization used for name and team membership lookup
+auth = Auth.Token(token_str)
+
+g = github.MainClass.Github(auth=auth)
+cable_lsm = g.get_organization('CABLE-LSM')
+dev_team = cable_lsm.get_team_by_slug('devs')
+
+# Use the dictionary t_users to collect users for Tractive
+t_users = dict()
+
+with open(args.map,'r') as m:
+    for m_line in m:
+        time.sleep(4)
+        m_match = m_pattern.match(m_line.rstrip())
+        m_user = m_match.group('m_user')
+        m_name = m_match.group('m_name')
+        m_email = m_match.group('m_email')
+        print('[',m_user,']', file=sys.stderr, flush=True)
+
+        # Set a default GitHub username
+        t_username = 'ccarouge'
+        if len(m_name) > 0:
+            # Look up c_user_name as a GitHub user
+            g_result = g.search_users(m_name)
+            if g_result.totalCount > 0:
+                g_named_user = g_result[0]
+                # Look up the GitHub user as a CABLE-LSM dev team member
+                if dev_team.has_in_members(g_named_user):
+                    t_username = g_named_user.login
+
+        t_users[m_user] = {
+                    'email': m_email,
+                    'name': m_name,
+                    'username': t_username}
+    t_yaml = {'users': t_users}
+    print(yaml.dump(t_yaml, Dumper=yaml.Dumper))
+

--- a/Trac-to-Github-migration/bin/create_tractive_users_as_devs.py
+++ b/Trac-to-Github-migration/bin/create_tractive_users_as_devs.py
@@ -1,4 +1,6 @@
 #!/bin/env python
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import github

--- a/Trac-to-Github-migration/bin/format_author_map.py
+++ b/Trac-to-Github-migration/bin/format_author_map.py
@@ -1,0 +1,44 @@
+#!/bin/env python
+
+import argparse
+import re
+import sys
+import time
+
+m_str = r'(?P<m_user>.*) = .*'
+u_str = r'(?P<u_user>.*) = (?P<u_name>.*)'
+m_pattern = re.compile(m_str)
+u_pattern = re.compile(u_str)
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+        'map', 
+        nargs='?',
+        default='cable.sorted.map')
+parser.add_argument(
+        'users', 
+        nargs='?',
+        default='current_cable_users.clean.txt')
+args = parser.parse_args()
+
+with open(args.users,'r') as u:
+    u_lines = u.readlines()
+with open(args.map,'r') as m: 
+    for m_line in m:
+        m_match = m_pattern.match(m_line)
+        if m_match is not None:
+            m_user = m_match.group('m_user')
+            found = False
+            for u_line in u_lines:
+                u_match = u_pattern.match(u_line)
+                u_user = u_match.group('u_user')
+                if u_user == m_user:
+                    found = True
+                    u_name = u_match.group('u_name')
+                    break
+            output = (
+                    f'{m_user} = {u_name} <{m_user}@nci.org.au>'
+                    if found else
+                    f'{m_user} = {m_user} <{m_user}@nci.org.au>')
+            print(output, flush=True)
+

--- a/Trac-to-Github-migration/bin/format_author_map.py
+++ b/Trac-to-Github-migration/bin/format_author_map.py
@@ -1,4 +1,6 @@
 #!/bin/env python
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import re

--- a/Trac-to-Github-migration/bin/format_github_map.py
+++ b/Trac-to-Github-migration/bin/format_github_map.py
@@ -1,0 +1,45 @@
+#!/bin/env python
+
+import argparse
+import re
+import sys
+import time
+
+m_str = r'(?P<m_user>.*) = (?P<m_name>.*) <(?P<m_email>.*)>'
+u_str = r'(?P<u_user>.*) = (?P<u_name>.*)'
+m_pattern = re.compile(m_str)
+u_pattern = re.compile(u_str)
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+        'map', 
+        nargs='?',
+        default='cable.github.map')
+parser.add_argument(
+        'users', 
+        nargs='?',
+        default='current_cable_users.github.extra.sorted.txt')
+args = parser.parse_args()
+
+with open(args.map,'r') as m:
+    m_lines = m.readlines()
+with open(args.users,'r') as u:
+    for u_line in u:
+        u_match = u_pattern.match(u_line.rstrip())
+        if u_match is not None:
+            u_user = u_match.group('u_user')
+            u_name = u_match.group('u_name')
+            found = False
+            for m_line in m_lines:
+                m_match = m_pattern.match(m_line.rstrip())
+                m_name = m_match.group('m_name')
+                if m_name == u_name:
+                    found = True
+                    m_email = m_match.group('m_email')
+                    break
+            output = (
+                    f'{u_user} = {u_name} <{m_email}>'
+                    if found else
+                    f'{u_user} = {u_name} <{u_user}@nci.org.au>')
+            print(output, flush=True)
+

--- a/Trac-to-Github-migration/bin/format_github_map.py
+++ b/Trac-to-Github-migration/bin/format_github_map.py
@@ -1,4 +1,6 @@
 #!/bin/env python
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import re

--- a/Trac-to-Github-migration/bin/install-tractive.sh
+++ b/Trac-to-Github-migration/bin/install-tractive.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+conda_env_tractive() {
+    my_conda_env='/g/data/tm70/pcl851/envs/tractive'
+    my_conda_setup="$("${my_conda_env}/bin/conda" 'shell.bash' 'hook' 2> /dev/null)"
+    if [ $? -eq 0 ]; then
+        eval "$my_conda_setup"
+    else
+        if [ -f "${my_conda_env}/etc/profile.d/conda.sh" ]; then
+            . "${my_conda_env}/etc/profile.d/conda.sh"
+        else
+            export PATH="${my_conda_env}/bin:$PATH"
+        fi
+    fi
+}
+
+module use /g/data/hh5/public/modules
+module load conda/analysis3-23.07
+conda create -y --prefix /g/data/tm70/pcl851/envs/tractive conda
+conda_env_tractive
+conda install -y conda -c conda-forge
+conda install -y ruby
+conda install -y reposurgeon -c dnachun
+conda install -y pygithub -c conda-forge
+conda install -y gcc_linux-64
+conda install -y gxx_linux-64
+gem install -q ruby
+gem install -q tractive
+

--- a/Trac-to-Github-migration/bin/install-tractive.sh
+++ b/Trac-to-Github-migration/bin/install-tractive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+tractive_env="/g/data/tm70/pcl851/envs/tractive"
 conda_env_tractive() {
-    my_conda_env='/g/data/tm70/pcl851/envs/tractive'
+    my_conda_env="$tractive_env"
     my_conda_setup="$("${my_conda_env}/bin/conda" 'shell.bash' 'hook' 2> /dev/null)"
     if [ $? -eq 0 ]; then
         eval "$my_conda_setup"
@@ -16,12 +16,14 @@ conda_env_tractive() {
 
 module use /g/data/hh5/public/modules
 module load conda/analysis3-23.07
-conda create -y --prefix /g/data/tm70/pcl851/envs/tractive conda
+conda create -y --prefix "$tractive_env" conda
 conda_env_tractive
-conda install -y conda -c conda-forge
+conda install -y -c conda-forge conda
 conda install -y ruby
-conda install -y reposurgeon -c dnachun
+conda install -y -c dnachun reposurgeon
 conda install -y pygithub -c conda-forge
+conda install -y -c conda-forge git-filter-repo
+conda install -y pyyaml
 conda install -y gcc_linux-64
 conda install -y gxx_linux-64
 gem install -q ruby

--- a/Trac-to-Github-migration/bin/install-tractive.sh
+++ b/Trac-to-Github-migration/bin/install-tractive.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 tractive_env="/g/data/tm70/pcl851/envs/tractive"
 conda_env_tractive() {
     my_conda_env="$tractive_env"


### PR DESCRIPTION
Add Bash and Python scripts used to migrate CABLE Trac to GitHub, as documented in the [Trac-to-Github-migration](https://github.com/ACCESS-NRI/dev-docs/wiki/Trac-to-Github-migration) Wiki page.
